### PR TITLE
Add a config that allows users to specify Presidio Containers or a Local Library

### DIFF
--- a/docker/config.yaml
+++ b/docker/config.yaml
@@ -1,1 +1,40 @@
-# Please replace this with your own configuration file
+receivers:
+  otlp:
+    protocols:
+      grpc:
+        endpoint: 0.0.0.0:4317
+      http:
+        endpoint: 0.0.0.0:4318
+
+processors:
+  # Refer to schema.yaml for configuration options
+  presidio_redaction:
+    presidio_service:
+      use_docker: false
+      docker_analyzer_endpoint: http://host.docker.internal:5002/analyze
+      docker_anonymizer_endpoint: http://host.docker.internal:5001/anonymize
+      concurrency_limit: 1 # Default to 1, pending https://github.com/microsoft/presidio/pull/1497
+      python_path: "."
+    analyzer:
+      language: "en"
+      score_threshold: 0.5
+    anonymizer:
+      anonymizers:
+        - entity: "DEFAULT"
+          type: "HASH"
+          hash_type: "sha256"
+
+exporters:
+  debug:
+    verbosity: detailed
+
+service:
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [presidio_redaction]
+      exporters: [debug]
+    logs:
+      receivers: [otlp]
+      processors: [presidio_redaction]
+      exporters: [debug]

--- a/docker/schema.yaml
+++ b/docker/schema.yaml
@@ -1,0 +1,147 @@
+type: object
+properties:
+  processors:
+    type: object
+    properties:
+      presidio_redaction:
+        type: object
+        properties:
+          presidio_service:
+            type: object
+            properties:
+              use_docker:
+                type: boolean
+                description: Flag to determine if Docker container should be used for the analyzer.
+              docker_analyzer_endpoint:
+                type: string
+                description: URL of the Presidio Analyzer service, responsible for detecting PII entities.
+              docker_anonymizer_endpoint:
+                type: string
+                description: URL of the Presidio Anonymizer service, responsible for transforming detected PII.
+              concurrency_limit:
+                type: integer
+                description: |
+                  Maximum number of concurrent requests to the analyzer and anonymizer.
+                  Default is 1. Increase cautiously based on system performance and stability.
+              python_path:
+                type: string
+                description: Path to the Python executable for the analyzer.
+          analyzer:
+            type: object
+            properties:
+              language:
+                type: string
+                description: "Language code for text analysis. Supported values: en, es, etc."
+              score_threshold:
+                type: number
+                description: |
+                  Confidence score threshold to consider an entity as PII.
+                  Entities with scores below this value will be ignored. Range: 0.0–1.0.
+              entities:
+                type: string
+                description: |
+                  List of entities to detect. Use "DEFAULT" to detect all supported entities.
+                  Full list of Supported Entities: https://microsoft.github.io/presidio/supported_entities/
+              context:
+                type: array
+                items:
+                  type: string
+                description: |
+                  List of context words which may help to raise recognized entities confidence
+          anonymizer:
+            type: object
+            properties:
+              anonymizers:
+                type: array
+                description: List of anonymizer configurations to be applied to detected PII entities.
+                items:
+                  type: object
+                  properties:
+                    entity:
+                      type: string
+                      description: |
+                        Entity type for which this anonymizer is applied. Examples:
+                        - "PHONE_NUMBER", "EMAIL_ADDRESS", "CREDIT_CARD", "LOCATION", etc.
+                        - Full list of Supported Entities: https://microsoft.github.io/presidio/supported_entities/
+                        Use "DEFAULT" to define a fallback for entities not explicitly listed.
+                    type:
+                      type: string
+                      enum:
+                        - REPLACE
+                        - HASH
+                        - REDACT
+                        - MASK
+                        - ENCRYPT
+                      description: |
+                        Anonymization method. Supported types:
+                        - REPLACE: Replace detected entity with a specific value.
+                        - HASH: Replace detected entity with a hashed version.
+                        - REDACT: Remove the detected entity from the text.
+                        - MASK: Mask parts of the detected entity.
+                        - ENCRYPT: Replace detected entity with an encrypted version.
+                    new_value:
+                      type: string
+                      description: Replacement value (required for REPLACE type).
+                    chars_to_mask:
+                      type: array
+                      items:
+                        type: integer
+                      description: |
+                        (For MASK type) List of character positions to mask in the detected entity.
+                        Example: [0, 3] masks the 1st and 4th characters.
+                    masking_char:
+                      type: string
+                      description: |
+                        (For MASK type) Character to use for masking. Default is "*".
+                    from_end:
+                      type: boolean
+                      description: |
+                        (For MASK type) Mask characters from the end of the entity.
+                        Default is false (mask from the beginning).
+                    hash_type:
+                      type: string
+                      description: |
+                        (For HASH type) Specify the hash algorithm (supported algorithms: sha256, sha512, "md5).
+                    key:
+                      type: string
+                      description: |
+                        (For ENCRYPT type) Encryption key for secure transformations.
+                  required:
+                    - entity
+                    - type
+                  oneOf:
+                    - properties:
+                        type:
+                          const: REPLACE
+                        new_value:
+                          type: string
+                          description: Replacement value for REPLACE type.
+                      required: [new_value]
+                    - properties:
+                        type:
+                          const: HASH
+                        hash_algorithm:
+                          type: string
+                          description: Hash algorithm for HASH type.
+                      required: [hash_algorithm]
+                    - properties:
+                        type:
+                          const: MASK
+                        chars_to_mask:
+                          type: array
+                          items:
+                            type: integer
+                          description: Positions of characters to mask.
+                        masking_char:
+                          type: string
+                          description: Character used for masking.
+                      required: [chars_to_mask]
+                    - properties:
+                        type:
+                          const: ENCRYPT
+                        encryption_key:
+                          type: string
+                          description: Encryption key for ENCRYPT type.
+                      required: [encryption_key]
+required:
+  - processors

--- a/presidioredactionprocessor/config.go
+++ b/presidioredactionprocessor/config.go
@@ -8,7 +8,7 @@ type PresidioServiceConfig struct {
 	DockerAnalyzerEndpoint    string `mapstructure:"docker_analyzer_endpoint"`
 	DockerAnonymizerEndpoint  string `mapstructure:"docker_anonymizer_endpoint"`
 	ConcurrencyLimit          int    `mapstructure:"concurrency_limit,omitempty"`
-	PythonPath 	              string `mapstructure:"python_path"`
+	PythonPath 	              string `mapstructure:"python_path,omitempty"`
 }
 
 type Config struct {

--- a/presidioredactionprocessor/config.go
+++ b/presidioredactionprocessor/config.go
@@ -3,12 +3,18 @@
 
 package presidioredactionprocessor // import "github.com/open-telemetry/opentelemetry-collector-contrib/processor/redactionprocessor"
 
+type PresidioServiceConfig struct {
+	UseDocker 	              bool   `mapstructure:"use_docker"`
+	DockerAnalyzerEndpoint    string `mapstructure:"docker_analyzer_endpoint"`
+	DockerAnonymizerEndpoint  string `mapstructure:"docker_anonymizer_endpoint"`
+	ConcurrencyLimit          int    `mapstructure:"concurrency_limit,omitempty"`
+	PythonPath 	              string `mapstructure:"python_path"`
+}
+
 type Config struct {
-	AnalyzerEndpoint   string           `mapstructure:"analyzer_endpoint"`
-	AnonymizerEndpoint string           `mapstructure:"anonymizer_endpoint"`
-	AnalyzerConfig     AnalyzerConfig   `mapstructure:"analyzer"`
-	AnonymizerConfig   AnonymizerConfig `mapstructure:"anonymizer,omitempty"`
-	ConcurrencyLimit   int              `mapstructure:"concurrency_limit,omitempty"`
+	PresidioServiceConfig PresidioServiceConfig `mapstructure:"presidio_service"`
+	AnalyzerConfig        AnalyzerConfig   	    `mapstructure:"analyzer"`
+	AnonymizerConfig      AnonymizerConfig 	    `mapstructure:"anonymizer,omitempty"`
 }
 
 type AnalyzerConfig struct {

--- a/presidioredactionprocessor/processor.go
+++ b/presidioredactionprocessor/processor.go
@@ -11,6 +11,8 @@ import (
 	"net/http"
 	"strings"
 	"time"
+	"os/exec"
+	"path/filepath"
 
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -26,15 +28,15 @@ type presidioRedaction struct {
 }
 
 func newPresidioRedaction(_ context.Context, cfg *Config, logger *zap.Logger) *presidioRedaction {
-	if cfg.ConcurrencyLimit <= 0 {
-		cfg.ConcurrencyLimit = 1
+	if cfg.PresidioServiceConfig.ConcurrencyLimit <= 0 {
+		cfg.PresidioServiceConfig.ConcurrencyLimit = 1
 	}
 
 	return &presidioRedaction{
 		config:             cfg,
 		logger:             logger,
 		client:             &http.Client{},
-		concurrencyLimiter: make(chan struct{}, cfg.ConcurrencyLimit),
+		concurrencyLimiter: make(chan struct{}, cfg.PresidioServiceConfig.ConcurrencyLimit),
 	}
 }
 
@@ -152,25 +154,11 @@ func (s *presidioRedaction) callPresidioAnalyzer(ctx context.Context, value stri
 		return []PresidioAnalyzerResponse{}, fmt.Errorf("failed to marshal request payload: %v", err)
 	}
 
-	headers := map[string]string{
-		"Content-Type": "application/json",
+	if s.config.PresidioServiceConfig.UseDocker {
+		return s.callPresidioAnalyzerDocker(ctx, jsonPayload)
+	} else {
+		return s.callPresidioAnalyzerLocal(ctx, jsonPayload)
 	}
-
-	url := s.config.AnalyzerEndpoint
-
-	resp, err := s.sendHTTPRequest(ctx, http.MethodPost, url, jsonPayload, headers)
-	if err != nil {
-		return []PresidioAnalyzerResponse{}, err
-	}
-	defer resp.Body.Close()
-
-	var presidioAnalyzerResponse []PresidioAnalyzerResponse
-	err = json.NewDecoder(resp.Body).Decode(&presidioAnalyzerResponse)
-	if err != nil {
-		return []PresidioAnalyzerResponse{}, err
-	}
-
-	return presidioAnalyzerResponse, nil
 }
 
 func (s *presidioRedaction) callPresidioAnonymizer(ctx context.Context, value string, analyzerResults []PresidioAnalyzerResponse) (PresidioAnonymizerResponse, error) {
@@ -198,11 +186,62 @@ func (s *presidioRedaction) callPresidioAnonymizer(ctx context.Context, value st
 		return PresidioAnonymizerResponse{}, fmt.Errorf("failed to marshal request payload: %v", err)
 	}
 
+	if s.config.PresidioServiceConfig.UseDocker {
+		return s.callPresidioAnonymizerDocker(ctx, jsonPayload)
+	} else {
+		return s.callPresidioAnonymizerLocal(ctx, jsonPayload)
+	}
+
+	return PresidioAnonymizerResponse{}, fmt.Errorf("local anonymizer is not supported")
+}
+
+func (s *presidioRedaction) callPresidioAnalyzerDocker(ctx context.Context, jsonPayload []byte) ([]PresidioAnalyzerResponse, error) {
+	headers := map[string]string{
+		"Content-Type": "application/json",
+	}
+	url := s.config.PresidioServiceConfig.DockerAnalyzerEndpoint
+	resp, err := s.sendHTTPRequest(ctx, http.MethodPost, url, jsonPayload, headers)
+	if err != nil {
+		return []PresidioAnalyzerResponse{}, err
+	}
+	defer resp.Body.Close()
+
+	var presidioAnalyzerResponse []PresidioAnalyzerResponse
+	err = json.NewDecoder(resp.Body).Decode(&presidioAnalyzerResponse)
+	if err != nil {
+		return []PresidioAnalyzerResponse{}, err
+	}
+
+	return presidioAnalyzerResponse, nil
+}
+
+func (s *presidioRedaction) callPresidioAnalyzerLocal(ctx context.Context, jsonPayload []byte) ([]PresidioAnalyzerResponse, error) {
+	path := filepath.Join(s.config.PresidioServiceConfig.PythonPath, "analyzer.py")
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(jsonPayload)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return []PresidioAnalyzerResponse{}, fmt.Errorf("failed to execute command: %v", err)
+	}
+
+	var presidioAnalyzerResponse []PresidioAnalyzerResponse
+	err = json.NewDecoder(&out).Decode(&presidioAnalyzerResponse)
+	if err != nil {
+		return []PresidioAnalyzerResponse{}, err
+	}
+
+	return presidioAnalyzerResponse, nil
+}
+
+func (s *presidioRedaction) callPresidioAnonymizerDocker(ctx context.Context, jsonPayload []byte) (PresidioAnonymizerResponse, error) {
 	headers := map[string]string{
 		"Content-Type": "application/json",
 	}
 
-	url := s.config.AnonymizerEndpoint
+	url := s.config.PresidioServiceConfig.DockerAnonymizerEndpoint
 	resp, err := s.sendHTTPRequest(ctx, http.MethodPost, url, jsonPayload, headers)
 	if err != nil {
 		return PresidioAnonymizerResponse{}, err
@@ -211,6 +250,27 @@ func (s *presidioRedaction) callPresidioAnonymizer(ctx context.Context, value st
 
 	var presidioAnonymizerResponse PresidioAnonymizerResponse
 	err = json.NewDecoder(resp.Body).Decode(&presidioAnonymizerResponse)
+	if err != nil {
+		return PresidioAnonymizerResponse{}, err
+	}
+
+	return presidioAnonymizerResponse, nil
+}
+
+func (s *presidioRedaction) callPresidioAnonymizerLocal(ctx context.Context, jsonPayload []byte) (PresidioAnonymizerResponse, error) {
+	path := filepath.Join(s.config.PresidioServiceConfig.PythonPath, "anonymizer.py")
+	cmd := exec.Command(path)
+	cmd.Stdin = bytes.NewReader(jsonPayload)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+
+	err := cmd.Run()
+	if err != nil {
+		return PresidioAnonymizerResponse{}, fmt.Errorf("failed to execute command: %v", err)
+	}
+
+	var presidioAnonymizerResponse PresidioAnonymizerResponse
+	err = json.NewDecoder(&out).Decode(&presidioAnonymizerResponse)
 	if err != nil {
 		return PresidioAnonymizerResponse{}, err
 	}

--- a/presidioredactionprocessor/processor.go
+++ b/presidioredactionprocessor/processor.go
@@ -216,7 +216,7 @@ func (s *presidioRedaction) callPresidioAnalyzerDocker(ctx context.Context, json
 }
 
 func (s *presidioRedaction) callPresidioAnalyzerLocal(ctx context.Context, jsonPayload []byte) ([]PresidioAnalyzerResponse, error) {
-	path := filepath.Join(s.config.PresidioServiceConfig.PythonPath, "analyzer.py")
+	if _, err := os.Stat(path); os.IsNotExist(err) { return []PresidioAnalyzerResponse{}, fmt.Errorf("analyzer script not found at path: %s", path) }
 	cmd := exec.Command(path)
 	cmd.Stdin = bytes.NewReader(jsonPayload)
 	var out bytes.Buffer

--- a/presidioredactionprocessor/processor.go
+++ b/presidioredactionprocessor/processor.go
@@ -216,8 +216,11 @@ func (s *presidioRedaction) callPresidioAnalyzerDocker(ctx context.Context, json
 }
 
 func (s *presidioRedaction) callPresidioAnalyzerLocal(ctx context.Context, jsonPayload []byte) ([]PresidioAnalyzerResponse, error) {
-	if _, err := os.Stat(path); os.IsNotExist(err) { return []PresidioAnalyzerResponse{}, fmt.Errorf("analyzer script not found at path: %s", path) }
-	cmd := exec.Command(path)
+	path := filepath.Join(s.config.PresidioServiceConfig.PythonPath, "analyzer.py")
+	if _, err := os.Stat(path); os.IsNotExist(err) { 
+		return []PresidioAnalyzerResponse{}, fmt.Errorf("analyzer script not found at path: %s", path)
+	}
+	cmd := exec.Command("python", path)
 	cmd.Stdin = bytes.NewReader(jsonPayload)
 	var out bytes.Buffer
 	cmd.Stdout = &out
@@ -259,7 +262,10 @@ func (s *presidioRedaction) callPresidioAnonymizerDocker(ctx context.Context, js
 
 func (s *presidioRedaction) callPresidioAnonymizerLocal(ctx context.Context, jsonPayload []byte) (PresidioAnonymizerResponse, error) {
 	path := filepath.Join(s.config.PresidioServiceConfig.PythonPath, "anonymizer.py")
-	cmd := exec.Command(path)
+	if _, err := os.Stat(path); os.IsNotExist(err) { 
+		return []PresidioAnalyzerResponse{}, fmt.Errorf("anonymizer script not found at path: %s", path)
+	}
+	cmd := exec.Command("python", path)
 	cmd.Stdin = bytes.NewReader(jsonPayload)
 	var out bytes.Buffer
 	cmd.Stdout = &out


### PR DESCRIPTION
- Read config and decide whether to use Presidio Containers or a Local python script.
- @xinsnake is working on the Python script so it doesn't include it