### PR TITLE
Update workflow action to only run on merge to Main

### DIFF
--- a/.github/workflows/docker-build-CollectorOnly.yaml
+++ b/.github/workflows/docker-build-CollectorOnly.yaml
@@ -3,7 +3,6 @@ name: Build and Push Docker Image
 on:
   push:
     branches: [ "main" ]
-  pull_request:
 
 jobs:
   build-and-push-docker:


### PR DESCRIPTION
Removing trigger on PRs, so that it only triggers on merges to Main