### PR TITLE
Fix Docker Build Issues on Local

### DIFF
--- a/docker/CollectorWithPresidio.Dockerfile
+++ b/docker/CollectorWithPresidio.Dockerfile
@@ -16,12 +16,14 @@ ENV GOARCH=amd64
 
 RUN ./ocb --verbose --config builder-config.yaml
 
-FROM python:3.12-slim
+FROM condaforge/mambaforge
 WORKDIR /app
 
 COPY ./presidio_grpc_wrapper/requirements.txt /app
-RUN pip install -r requirements.txt && \
-    python -m spacy download en_core_web_lg
+
+RUN conda install -c conda-forge spacy && \
+  pip install -r requirements.txt && \
+  python -m spacy download en_core_web_lg
 
 COPY --from=builder /app/_build/otelcol-presidio ./otel-collector
 COPY ./docker/config.yaml .

--- a/docker/CollectorWithPresidio.entrypoint.sh
+++ b/docker/CollectorWithPresidio.entrypoint.sh
@@ -7,7 +7,7 @@ python /app/server.py &
 PROCESSOR_A_PID=$!
 
 # Start Processor B in the background
-echo "Starting OPTL Collector..."
+echo "Starting OTLP Collector..."
 ./otel-collector --config /app/config.yaml &
 PROCESSOR_B_PID=$!
 

--- a/docker/CollectorWithPresidio.local.Dockerfile
+++ b/docker/CollectorWithPresidio.local.Dockerfile
@@ -16,12 +16,14 @@ ENV GOARCH=amd64
 
 RUN ./ocb --verbose --config builder-config.yaml
 
-FROM python:3.12-slim
+FROM condaforge/mambaforge
 WORKDIR /app
 
 COPY ./presidio_grpc_wrapper/requirements.txt /app
-RUN pip install -r requirements.txt && \
-    python -m spacy download en_core_web_lg
+
+RUN conda install -c conda-forge spacy && \
+  pip install -r requirements.txt && \
+  python -m spacy download en_core_web_lg
 
 COPY --from=builder /app/_build/otelcol-presidio ./otel-collector
 COPY ./docker/config.yaml .


### PR DESCRIPTION
The Docker Containers containing the Presidio gRPC server were failing when building locally on ARM based architectures.

This is due to the inclusion of the [BLIS](https://github.com/explosion/cython-blis#building-blis-for-alternative-architectures) package which is used by spaCy to perform vector operations. 

BLIS doesn't have great support for alternative architectures. This PR switches the base image to a conda based image, which contains the pre-built binaries for BLIS, negating the need to build it from source.
