### PR TITLE
update base image for dockerfile with Presidio

### DIFF
--- a/docker/CollectorWithPresidio.Dockerfile
+++ b/docker/CollectorWithPresidio.Dockerfile
@@ -16,7 +16,7 @@ ENV GOARCH=amd64
 
 RUN ./ocb --verbose --config builder-config.yaml
 
-FROM condaforge/mambaforge
+FROM continuumio/miniconda3:latest
 WORKDIR /app
 
 COPY ./presidio_grpc_wrapper/requirements.txt /app


### PR DESCRIPTION
Updating the base image from condaforge/mambaforge to continuumio/miniconda3, due to GLIBC requirements by the Otel Collector Builder. 

GLIBC >= 2.32 is required, whereas mambaforge only has 2.31. 